### PR TITLE
tune speed

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -209,6 +209,7 @@ def handler(job):
     prompt["235"]["inputs"]["value"] = adjusted_width
     prompt["236"]["inputs"]["value"] = adjusted_height
     prompt["498"]["inputs"]["context_overlap"] = job_input.get("context_overlap", 48)
+    prompt["498"]["inputs"]["context_frames"] = length
     
     # step 설정 적용
     if "834" in prompt:

--- a/handler.py
+++ b/handler.py
@@ -210,7 +210,7 @@ def handler(job):
     prompt["236"]["inputs"]["value"] = adjusted_height
     prompt["498"]["inputs"]["context_overlap"] = job_input.get("context_overlap", 48)
     prompt["498"]["inputs"]["context_frames"] = length
-    
+
     # step 설정 적용
     if "834" in prompt:
         prompt["834"]["inputs"]["steps"] = steps

--- a/new_Wan22_api.json
+++ b/new_Wan22_api.json
@@ -3,7 +3,7 @@
     "inputs": {
       "model": "Wan2_2-I2V-A14B-HIGH_fp8_e4m3fn_scaled_KJ.safetensors",
       "base_precision": "bf16",
-      "quantization": "disabled",
+      "quantization": "fp8_e4m3fn",
       "load_device": "offload_device",
       "attention_mode": "sageattn",
       "rms_norm_function": "default"
@@ -265,11 +265,11 @@
   },
   "525": {
     "inputs": {
-      "blocks_to_swap": 25,
+      "blocks_to_swap": 0,
       "enable_cuda_optimization": true,
       "enable_dram_optimization": true,
       "auto_hardware_tuning": false,
-      "vram_threshold_percent": 50,
+      "vram_threshold_percent": 90,
       "num_cuda_streams": 6,
       "bandwidth_target": 0.8,
       "offload_txt_emb": false,
@@ -368,7 +368,7 @@
     "inputs": {
       "model": "Wan2_2-I2V-A14B-LOW_fp8_e4m3fn_scaled_KJ.safetensors",
       "base_precision": "bf16",
-      "quantization": "disabled",
+      "quantization": "fp8_e4m3fn",
       "load_device": "offload_device",
       "attention_mode": "sageattn",
       "rms_norm_function": "default",

--- a/new_Wan22_flf2v_api.json
+++ b/new_Wan22_flf2v_api.json
@@ -3,7 +3,7 @@
     "inputs": {
       "model": "Wan2_2-I2V-A14B-HIGH_fp8_e4m3fn_scaled_KJ.safetensors",
       "base_precision": "bf16",
-      "quantization": "disabled",
+      "quantization": "fp8_e4m3fn",
       "load_device": "offload_device",
       "attention_mode": "sageattn",
       "rms_norm_function": "default"
@@ -269,11 +269,11 @@
   },
   "525": {
     "inputs": {
-      "blocks_to_swap": 25,
+      "blocks_to_swap": 0,
       "enable_cuda_optimization": true,
       "enable_dram_optimization": true,
       "auto_hardware_tuning": false,
-      "vram_threshold_percent": 50,
+      "vram_threshold_percent": 90,
       "num_cuda_streams": 6,
       "bandwidth_target": 0.8,
       "offload_txt_emb": false,
@@ -376,7 +376,7 @@
     "inputs": {
       "model": "Wan2_2-I2V-A14B-LOW_fp8_e4m3fn_scaled_KJ.safetensors",
       "base_precision": "bf16",
-      "quantization": "disabled",
+      "quantization": "fp8_e4m3fn",
       "load_device": "offload_device",
       "attention_mode": "sageattn",
       "rms_norm_function": "default",


### PR DESCRIPTION
tested on RTX 4090, 

- 81 frames, 8 steps, cfg 1, 480x832, **~180s ---> ~110s**
- 121 frames, 8 steps, cfg 1, 480x832, **-> ~180s**

change:
- quantization: none -> fp8_e4m3fn
- blocks_to_swap: 25 -> 0 
- vram_threshold_percent: 50 -> 90
- context_frames: follow frames value